### PR TITLE
Add github app manifest

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -1,0 +1,139 @@
+# This is a GitHub App Manifest. These settings will be used by default when
+# initially configuring your GitHub App.
+#
+# NOTE: changing this file will not update your GitHub App settings.
+# You must visit github.com/settings/apps/your-app-name to edit them.
+#
+# Read more about configuring your GitHub App:
+# https://probot.github.io/docs/development/#configuring-a-github-app
+#
+# Read more about GitHub App Manifests:
+# https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/
+
+# The list of events the GitHub App subscribes to.
+# Uncomment the event names below to enable them.
+default_events:
+# - check_run
+# - check_suite
+# - commit_comment
+# - create
+# - delete
+# - deployment
+# - deployment_status
+# - fork
+# - gollum
+# - issue_comment
+# - issues
+# - label
+# - milestone
+# - member
+# - membership
+# - org_block
+# - organization
+# - page_build
+# - project
+# - project_card
+# - project_column
+# - public
+- pull_request
+# - pull_request_review
+# - pull_request_review_comment
+# - push
+# - release
+# - repository
+# - repository_import
+# - status
+# - team
+# - team_add
+# - watch
+
+# The set of permissions needed by the GitHub App. The format of the object uses
+# the permission name for the key (for example, issues) and the access type for
+# the value (for example, write).
+# Valid values are `read`, `write`, and `none`
+default_permissions:
+  # Repository creation, deletion, settings, teams, and collaborators.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-administration
+  # administration: read
+
+  # Checks on code.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-checks
+  # checks: read
+
+  # Repository contents, commits, branches, downloads, releases, and merges.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-contents
+  # contents: read
+
+  # Deployments and deployment statuses.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-deployments
+  # deployments: read
+
+  # Issues and related comments, assignees, labels, and milestones.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-issues
+  # issues: read
+
+  # Search repositories, list collaborators, and access repository metadata.
+  # https://developer.github.com/v3/apps/permissions/#metadata-permissions
+  metadata: read
+
+  # Retrieve Pages statuses, configuration, and builds, as well as create new builds.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-pages
+  # pages: read
+
+  # Pull requests and related comments, assignees, labels, milestones, and merges.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
+  pull_requests: write
+
+  # Manage the post-receive hooks for a repository.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-repository-hooks
+  # repository_hooks: read
+
+  # Manage repository projects, columns, and cards.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-repository-projects
+  # repository_projects: read
+
+  # Retrieve security vulnerability alerts.
+  # https://developer.github.com/v4/object/repositoryvulnerabilityalert/
+  # vulnerability_alerts: read
+
+  # Commit statuses.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-statuses
+  # statuses: read
+
+  # Organization members and teams.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-members
+  # members: read
+
+  # View and manage users blocked by the organization.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-user-blocking
+  # organization_user_blocking: read
+
+  # Manage organization projects, columns, and cards.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-projects
+  # organization_projects: read
+
+  # Manage team discussions and related comments.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-team-discussions
+  # team_discussions: read
+
+  # Manage the post-receive hooks for an organization.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-hooks
+  # organization_hooks: read
+
+  # Get notified of, and update, content references.
+  # https://developer.github.com/v3/apps/permissions/
+  # organization_administration: read
+
+
+# The name of the GitHub App. Defaults to the name specified in package.json
+name: github-bot
+
+# The homepage of your GitHub App.
+url: https://github.com/elyra-ai/github-bot
+
+# A description of the GitHub App.
+description: An Elyra GitHub BOT to automate project related tasks
+
+# Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+# Default: true
+public: true


### PR DESCRIPTION
Add manifest yaml to automatically set permissions when registering the app



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

